### PR TITLE
Fixing JArray.GetEnumerator() Method Not Found Bug

### DIFF
--- a/LearnositySDK/Utils/JsonObjectFactory.cs
+++ b/LearnositySDK/Utils/JsonObjectFactory.cs
@@ -67,7 +67,7 @@ namespace LearnositySDK.Utils
 
             int index = 0;
 
-            foreach (JToken item in jArray)
+            foreach (JToken item in (IEnumerable<JToken>)jArray)
             {
                 jsonObject = JsonObjectFactory.fromJToken(jsonObject, index.ToString(), item);
                 index++;


### PR DESCRIPTION
This simple pull request fixes the bug linked [here](http://james.newtonking.com/archive/2013/11/29/fixing-jarray-getenumerator-method-not-found-bug).
Our application is currently locked to an older version of Newtonsoft which has this bug, and we're not able to upgrade this in the near future.