### PR TITLE
Upgrading to .NET Core 6.0

### DIFF
--- a/LearnosityDemo/LearnosityDemo.csproj
+++ b/LearnosityDemo/LearnosityDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LearnositySDKIntegrationTests/LearnositySDKIntegrationTests.csproj
+++ b/LearnositySDKIntegrationTests/LearnositySDKIntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/LearnositySDKUnitTests/LearnositySDKUnitTests.csproj
+++ b/LearnositySDKUnitTests/LearnositySDKUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
.NET Core 3.1 is past EOL. Just making a quick upgrde to the SDK here to use a supported version of .NET Core.