### PR TITLE
Handle wrond data format for decimal values causing overflow exception

### DIFF
--- a/LearnositySDK/Utils/JsonObjectFactory.cs
+++ b/LearnositySDK/Utils/JsonObjectFactory.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.IO;
+using System.Numerics;
+using System.Xml.Linq;
 
 namespace LearnositySDK.Utils
 {
@@ -98,7 +100,14 @@ namespace LearnositySDK.Utils
                     jsonObject.set(key, (int)item);
                     break;
                 case JTokenType.Float:
-                    jsonObject.set(key, (decimal)item);
+                    try
+                    {
+                        jsonObject.set(key, (float) item);
+                    }
+                    catch (OverflowException)
+                    {
+                        jsonObject.set(key, float.MaxValue);
+                    }
                     break;
                 case JTokenType.String:
                     jsonObject.set(key, (string)item);


### PR DESCRIPTION
An overflow exception was thrown while deserializing questions json, where a decimal value was too big (6e29)
The data found in the demo environment was fixed, so this change is not urgent but still worth checking in.